### PR TITLE
[BE] 플랜 연장, 조회, 등록 api 수정

### DIFF
--- a/src/architecture/repositories/plan.repository.ts
+++ b/src/architecture/repositories/plan.repository.ts
@@ -96,6 +96,19 @@ class PlanRepository {
 
     getInProgressPlans = async (userId: number) => {
         return this.planModel.findAll({
+            include: {
+                model: this.bookModel,
+                attributes: [
+                    "bookId",
+                    "title",
+                    "author",
+                    "publisher",
+                    "description",
+                    "coverImage",
+                    "isbn",
+                ],
+                required: false,
+            },
             where: {
                 userId,
                 status: "inProgress",

--- a/src/architecture/repositories/plan.repository.ts
+++ b/src/architecture/repositories/plan.repository.ts
@@ -1,5 +1,4 @@
 import { Op } from "sequelize";
-import getDateFormat from "../../util/setDateFormat";
 
 class PlanRepository {
     planModel: any;
@@ -188,6 +187,15 @@ class PlanRepository {
                 where: planId,
             },
         );
+    };
+
+    inProgressCount = async (userId: number) => {
+        return this.planModel.count({
+            where: {
+                userId,
+                status: "inProgress",
+            },
+        });
     };
 }
 

--- a/src/architecture/repositories/plan.repository.ts
+++ b/src/architecture/repositories/plan.repository.ts
@@ -184,7 +184,7 @@ class PlanRepository {
                 status: "restore",
             },
             {
-                where: planId,
+                where: { planId },
             },
         );
     };

--- a/src/architecture/services/plan.service.ts
+++ b/src/architecture/services/plan.service.ts
@@ -35,6 +35,11 @@ class PlanService {
         const newStartDate = new Date(startDate);
         const newEndDate = new Date(endDate);
 
+        if (newStartDate > newEndDate)
+            throw new Error(
+                "Bad Request : 종료일은 시작일보다 빠를 수 없습니다.",
+            );
+
         let bookData = await this.planRepository.findOneBook(newBookId);
 
         if (bookData === null) {

--- a/src/architecture/services/plan.service.ts
+++ b/src/architecture/services/plan.service.ts
@@ -299,16 +299,27 @@ class PlanService {
 
         let extendPlans: any = [];
 
+        let inProgressCount: number =
+            await this.planRepository.inProgressCount(userId);
+
         for (let i = 0; i < extendData.length; i++) {
+            if (inProgressCount > 2) {
+                extendPlans.push = {
+                    planId: extendData[i].planId,
+                    message: "이미 진행중인 플랜이 3개 이상입니다.",
+                };
+            }
+
             const oldPlan = await this.planRepository.findOnePlanById(
                 extendData[i].planId,
             );
 
-            if (oldPlan === null)
+            if (oldPlan === null) {
                 extendPlans.push = {
                     planId: extendData[i].planId,
                     message: "플랜을 찾을 수 없습니다.",
                 };
+            }
 
             const newPlan = await this.planRepository.createPlan(
                 oldPlan.totalPage,
@@ -343,6 +354,8 @@ class PlanService {
                 status: newPlan.status,
             };
         }
+
+        inProgressCount++;
 
         return extendData;
     };

--- a/src/architecture/services/plan.service.ts
+++ b/src/architecture/services/plan.service.ts
@@ -307,7 +307,7 @@ class PlanService {
 
             const newPlan = await this.planRepository.createPlan(
                 oldPlan.totalPage,
-                oldPlan.startDate,
+                new Date(getDateFormat(new Date())),
                 extendData[i].endDate,
                 userId,
                 oldPlan.bookId,

--- a/src/architecture/services/plan.service.ts
+++ b/src/architecture/services/plan.service.ts
@@ -167,7 +167,19 @@ class PlanService {
             );
         }
 
-        return previousPlans;
+        return previousPlans.map((plan: any) => {
+            return {
+                planId: plan.planId,
+                title: plan["Book.title"],
+                author: plan["Book.author"],
+                coverImage: plan["Book.coverImage"],
+                publisher: plan["Book.publisher"],
+                totalPage: plan.totalPage,
+                currentPage: plan.currentPage,
+                startDate: plan.startDate,
+                endDate: plan.endDate,
+            };
+        });
     };
 
     weedRecord = async (userId: number, date: string) => {

--- a/src/architecture/services/plan.service.ts
+++ b/src/architecture/services/plan.service.ts
@@ -327,7 +327,7 @@ class PlanService {
             };
         }
 
-        return extendPlans;
+        return extendData;
     };
 }
 


### PR DESCRIPTION
- 플랜 연장 - 시작일 변경, 실패 경우의 수 추가, response 변경
- 플랜 조회 - previousPlan에 책 정보 추가
- 플랜 등록 - 종료일이 시작일보다 빠를 경우 error 생성