### PR TITLE
:bug: Fix : 변수 선언 위치 변경 및 함수 전달 인자 수정

### DIFF
--- a/src/util/googleSheet/getData.js
+++ b/src/util/googleSheet/getData.js
@@ -1,14 +1,8 @@
 import { Op } from "sequelize";
 import { Plan, Record, User } from "../../db/models/domain/Tables";
-import getDateFormat from "../setDateFormat";
-
-const newDate = new Date();
-export const today = getDateFormat(
-    new Date(newDate.setDate(newDate.getDate() - 1)),
-);
 
 //일간 신규 유입
-export const getTodayNewUser = async () => {
+export const getTodayNewUser = async (today) => {
     return User.count({
         where: {
             createdAt: { [Op.like]: today },
@@ -30,7 +24,7 @@ export const getPlanSuccessPerPlanCreate = async () => {
 };
 
 //(달성 체크한 플랜 개수 / 전체 유저의 진행중 플랜 개수)
-export const getRecordPerInProgressPlan = async () => {
+export const getRecordPerInProgressPlan = async (today) => {
     const inProgressPlan = await Plan.count({
         where: {
             status: "inProgress",

--- a/src/util/googleSheet/google_sheets.js
+++ b/src/util/googleSheet/google_sheets.js
@@ -4,8 +4,8 @@ import {
     getPlanSuccessPerPlanCreate,
     getRecordPerInProgressPlan,
     getTodayNewUser,
-    today,
 } from "./getData";
+import getDateFormat from "../setDateFormat";
 
 export default async function data() {
     const client = new google.auth.JWT(
@@ -22,15 +22,20 @@ export default async function data() {
             updateData(client);
         }
     });
+    const newDate = new Date();
+    const today = getDateFormat(
+        new Date(newDate.setDate(newDate.getDate() - 1)),
+    );
+
     async function updateData(client) {
         const sheets = google.sheets({ version: "v4", auth: client });
         const getToday = today;
-        const todayNewUser = await getTodayNewUser();
+        const todayNewUser = await getTodayNewUser(today);
         const planSuccessPerPlanCreate =
             (await getPlanSuccessPerPlanCreate()) + "%";
         const recordPerInProgressPlan =
             (await getRecordPerInProgressPlan()) + "%";
-        const failedPlanPerPlan = (await getFailedPlanPerPlan()) + "%";
+        const failedPlanPerPlan = (await getFailedPlanPerPlan(today)) + "%";
         const todayData = new Array(
             getToday,
             "개발중",


### PR DESCRIPTION
[문제] 배포된 날짜의 데이터만 지속적으로 조회 됨
[원인] 변수가 선언 된 순간이 함수 밖에 위치해 배포 시 날짜로 고정되어버리는 문제
[해결] 변수를 실행되는 함수안으로 옮겨 함수 실행시에 날짜를 계속해서 업데이트 시켜주도록 변경